### PR TITLE
CNDIT-1024 : Convert Provider to kafka streams

### DIFF
--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/config/KafkaConfig.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/config/KafkaConfig.java
@@ -1,5 +1,6 @@
 package gov.cdc.etldatapipeline.changedata.config;
 
+import lombok.Getter;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -7,9 +8,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
 
 @Configuration
+@Getter
 public class KafkaConfig {
     @Value("${spring.kafka.stream.input.nbs-pages.topic-name}")
     private String nbsPagesTopicName;
+    @Value("${spring.kafka.stream.input.provider.topic-name}")
+    private String providerTopicName;
+    @Value("${spring.kafka.stream.input.provider.output-topic-name}")
+    private String providerAggregateTopicName;
     @Value("${spring.kafka.stream.input.person.topic-name}")
     private String personTopicName;
     @Value("${spring.kafka.stream.input.participation.topic-name}")
@@ -23,22 +29,12 @@ public class KafkaConfig {
     }
 
     @Bean
-    public String getNbsPagesTopicName() {
-        return nbsPagesTopicName;
+    public NewTopic createProviderTopicName() {
+        return TopicBuilder.name(providerTopicName).build();
     }
 
     @Bean
-    public String getPersonTopicName() {
-        return personTopicName;
-    }
-
-    @Bean
-    public String getParticipationTopicName() {
-        return participationTopicName;
-    }
-
-    @Bean
-    public String getCtContactTopicName() {
-        return ctContactTopicName;
+    public NewTopic createAggregateProviderTopicName() {
+        return TopicBuilder.name(providerAggregateTopicName).build();
     }
 }

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/config/KafkaStreamsConfig.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/config/KafkaStreamsConfig.java
@@ -1,5 +1,6 @@
 package gov.cdc.etldatapipeline.changedata.config;
 
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -21,11 +22,19 @@ public class KafkaStreamsConfig {
 	@Value("${spring.kafka.streams.application-id}")
 	private String applicationId;
 
+	@Value("${spring.kafka.producer.key-serializer}")
+	private String keySerializer;
+
+	@Value("${spring.kafka.producer.value-serializer}")
+	private String valueSerializer;
+
 	@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
 	public KafkaStreamsConfiguration kStreamsConfigs() {
 		Map<String, Object> props = new HashMap<>();
 		props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		props.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer);
+		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer);
 
 		return new KafkaStreamsConfiguration(props);
 	}

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/controller/DataPipelineController.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/controller/DataPipelineController.java
@@ -1,18 +1,26 @@
 package gov.cdc.etldatapipeline.changedata.controller;
 
+import gov.cdc.etldatapipeline.changedata.config.KafkaStreamsConfig;
 import gov.cdc.etldatapipeline.changedata.service.DataPipelineStatusService;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 public class DataPipelineController {
     private static final Logger LOG = LoggerFactory.getLogger(DataPipelineController.class);
 
     DataPipelineStatusService dataPipelineStatusSvc;
+
+    @Autowired
+    private KafkaStreamsConfig kafkaStreamsConfig;
 
     public DataPipelineController(DataPipelineStatusService dataPipelineStatusSvc) {
         this.dataPipelineStatusSvc = dataPipelineStatusSvc;
@@ -25,4 +33,14 @@ public class DataPipelineController {
        return this.dataPipelineStatusSvc.getHealthStatus();
     }
 
+    @PostMapping(value = "/provider", consumes = "application/json", produces = "application/json")
+    @ResponseBody
+    public ResponseEntity<String> postProvider(@RequestBody List<String> providerUids){
+        KafkaProducer<String,List<String>> producer = new KafkaProducer<>(
+                kafkaStreamsConfig.kStreamsConfigs().asProperties());
+        producer.send(new ProducerRecord<>("cdc.nbs_odse.dbo.Provider",
+                UUID.randomUUID().toString(), providerUids));
+        producer.close();
+        return ResponseEntity.ok("Produced : " + providerUids);
+    }
 }

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/model/dto/InitPatient.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/model/dto/InitPatient.java
@@ -1,4 +1,4 @@
-package gov.cdc.etldatapipeline.changedata.model.rdb;
+package gov.cdc.etldatapipeline.changedata.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import gov.cdc.etldatapipeline.changedata.model.odse.CtContact;

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/model/dto/Provider.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/model/dto/Provider.java
@@ -1,0 +1,40 @@
+package gov.cdc.etldatapipeline.changedata.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import gov.cdc.etldatapipeline.changedata.model.odse.DebeziumMetadata;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Data
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Provider extends DebeziumMetadata {
+    @Id
+    @Column(name = "PROVIDER_UID")
+    private String providerUid;
+    @Column(name = "PROVIDER_LOCAL_ID")
+    private String providerLocalId;
+    @Column(name = "PROVIDER_GENERAL_COMMENTS")
+    private String providerGeneralComments;
+    @Column(name = "PROVIDER_ENTRY_METHOD")
+    private String providerEntryMethod;
+    @Column(name = "PROVIDER_MPR_UID")
+    private String providerMprUid;
+    @Column(name = "PROVIDER_LAST_CHANGE_TIME")
+    private String providerLastChangeTime;
+    @Column(name = "PROVIDER_ADD_TIME")
+    private String providerAddTime;
+    @Column(name = "PROVIDER_RECORD_STATUS")
+    private String providerRecordStatus;
+    @Column(name = "ADD_USER_ID")
+    private String addUserId;
+    @Column(name = "LAST_CHG_USER_ID")
+    private String lastChgUserId;
+}
+

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/model/odse/DebeziumMetadata.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/model/odse/DebeziumMetadata.java
@@ -4,8 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Column;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Data
+@ToString
+@EqualsAndHashCode
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DebeziumMetadata {
     @Column(name = "ts_ms")

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/repository/PatientRepository.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/repository/PatientRepository.java
@@ -1,6 +1,6 @@
 package gov.cdc.etldatapipeline.changedata.repository;
 
-import gov.cdc.etldatapipeline.changedata.model.rdb.InitPatient;
+import gov.cdc.etldatapipeline.changedata.model.dto.InitPatient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/repository/ProviderRepository.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/repository/ProviderRepository.java
@@ -1,0 +1,15 @@
+package gov.cdc.etldatapipeline.changedata.repository;
+
+import gov.cdc.etldatapipeline.changedata.model.dto.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProviderRepository extends JpaRepository<Provider, String> {
+    @Query(nativeQuery = true, value = "execute sp_D_PROVIDER_EVENT :person_uids")
+    List<Provider> getAllProviders(@Param("person_uids") String provider_ids);
+}

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/service/KafkaStreamsService.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/service/KafkaStreamsService.java
@@ -2,6 +2,7 @@ package gov.cdc.etldatapipeline.changedata.service;
 
 import gov.cdc.etldatapipeline.changedata.repository.PageRepository;
 import gov.cdc.etldatapipeline.changedata.repository.PatientRepository;
+import gov.cdc.etldatapipeline.changedata.repository.ProviderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -17,8 +18,13 @@ public class KafkaStreamsService {
 
     private final PatientRepository patientRepository;
     private final PageRepository pageRepository;
+    private final ProviderRepository providerRepository;
     @Value("#{kafkaConfig.getNbsPagesTopicName()}")
     private String nbsPagesTopicName;
+    @Value("#{kafkaConfig.getProviderTopicName()}")
+    private String providerTopicName;
+    @Value("#{kafkaConfig.providerAggregateTopicName()}")
+    private String providerOutputTopicName;
     @Value("#{kafkaConfig.getPersonTopicName()}")
     private String personTopicName;
     @Value("#{kafkaConfig.getParticipationTopicName()}")
@@ -28,12 +34,23 @@ public class KafkaStreamsService {
 
     @Autowired
     public void processMessage(StreamsBuilder streamsBuilder) {
-        PatientService patientService = new PatientService(personTopicName,
-                participationTopicName, ctContactTopicName, patientRepository);
-        patientService.processPatientData(streamsBuilder);
 
-        NbsPageService pageService = new NbsPageService(nbsPagesTopicName,
+        ProviderService providerService = new ProviderService(
+                providerTopicName,
+                providerOutputTopicName,
+                providerRepository);
+        providerService.processProviderData(streamsBuilder);
+
+             /* PatientService patientService = new PatientService(
+                personTopicName,
+                participationTopicName,
+                ctContactTopicName,
+                patientRepository);
+        patientService.processPatientData(streamsBuilder);*/
+
+        /*NbsPageService pageService = new NbsPageService(
+                nbsPagesTopicName,
                 pageRepository);
-        pageService.processNbsPage(streamsBuilder);
+        pageService.processNbsPage(streamsBuilder);*/
     }
 }

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/service/KafkaStreamsService.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/service/KafkaStreamsService.java
@@ -23,7 +23,7 @@ public class KafkaStreamsService {
     private String nbsPagesTopicName;
     @Value("#{kafkaConfig.getProviderTopicName()}")
     private String providerTopicName;
-    @Value("#{kafkaConfig.providerAggregateTopicName()}")
+    @Value("#{kafkaConfig.getProviderAggregateTopicName()}")
     private String providerOutputTopicName;
     @Value("#{kafkaConfig.getPersonTopicName()}")
     private String personTopicName;

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/service/PatientService.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/service/PatientService.java
@@ -3,7 +3,7 @@ package gov.cdc.etldatapipeline.changedata.service;
 import gov.cdc.etldatapipeline.changedata.model.odse.CtContact;
 import gov.cdc.etldatapipeline.changedata.model.odse.Participation;
 import gov.cdc.etldatapipeline.changedata.model.odse.Person;
-import gov.cdc.etldatapipeline.changedata.model.rdb.InitPatient;
+import gov.cdc.etldatapipeline.changedata.model.dto.InitPatient;
 import gov.cdc.etldatapipeline.changedata.repository.PatientRepository;
 import gov.cdc.etldatapipeline.changedata.utils.StreamsSerdes;
 import gov.cdc.etldatapipeline.changedata.utils.UtilHelper;

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/service/ProviderService.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/service/ProviderService.java
@@ -1,0 +1,101 @@
+package gov.cdc.etldatapipeline.changedata.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import gov.cdc.etldatapipeline.changedata.model.dto.Provider;
+import gov.cdc.etldatapipeline.changedata.repository.ProviderRepository;
+import gov.cdc.etldatapipeline.changedata.utils.StreamsSerdes;
+import gov.cdc.etldatapipeline.changedata.utils.UtilHelper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ProviderService {
+
+    private static final String PROVIDER_STORE = "provider-store";
+
+    private static final Serde<String> STRING_SERDE = Serdes.String();
+
+    private final UtilHelper utilHelper = UtilHelper.getInstance();
+
+    private final String providerTopicName;
+    private final String providerOutputTopicName;
+    private final ProviderRepository providerRepository;
+
+
+    public void processProviderData(StreamsBuilder streamsBuilder) {
+        CollectionType stringListJavaType = new ObjectMapper().getTypeFactory()
+                .constructCollectionType(List.class, String.class);
+        KStream<String, List<String>> personInputKStream =
+                streamsBuilder.stream(
+                                providerTopicName,
+                                Consumed.with(STRING_SERDE, STRING_SERDE))
+                        .map((k, v) -> new KeyValue<>(
+                                k,
+                                utilHelper.deserializePayload(v,
+                                        stringListJavaType)));
+
+        log.info("Calling the Provider Repository.");
+        List<Provider> providerList = new ArrayList<>();
+        personInputKStream.foreach((k, v) -> providerList.addAll(
+                providerRepository.getAllProviders(String.join(",", v))));
+
+        KStream<String, Provider> consolidatedProviderStream
+                = personInputKStream.flatMap((k, v) -> providerRepository
+                .getAllProviders(String.join(",", v))
+                .stream().map(p -> KeyValue.pair(p.getProviderUid(), p))
+                .collect(Collectors.toSet()));
+
+        consolidatedProviderStream.foreach((k,v) -> log.info("Provider Info : ", v.toString()));
+        consolidatedProviderStream.to(providerOutputTopicName,
+                Produced.with(Serdes.String(), StreamsSerdes.ProviderSerde()));
+
+        //personTable.toStream().foreach((k,v) -> providerRepository.save(v));
+    }
+}
+
+/**
+ * NBS_ODSE.dbo.PERSON, NBS_ODSE.dbo.PERSON_NAME,
+ * ENTITY_LOCATOR_PARTICIPATION, NBS_ODSE.dbo.POSTAL_LOCATOR, NBS_ODSE.dbo
+ * .TELE_LOCATOR
+ * 1. TMP_S_PROVIDER_INIT - Get all persons - NBS_ODSE.dbo.PERSON, who are
+ * type provider that got changed since last run
+ * 2. TMP_PROVIDER_UID_COLL - Collect all the Person_UID from
+ * TMP_S_PROVIDER_INIT (Step 1)
+ * 3. TMP_S_INITPROVIDER - Provider + AuthUser - Join TMP_S_PROVIDER_INIT and
+ * AuthUser - Get Provider Added by/Changed by
+ * 4. TMP_S_PROVIDER_NAME - Extract Provider Names by joining
+ * TMP_PROVIDER_UID_COLL + NBS_ODSE.dbo.PERSON_NAME
+ * 5. TMP_S_PROVIDER_WITH_NM - Join TMP_S_PROVIDER_INIT + TMP_S_PROVIDER_NAME
+ * 6. TMP_S_PROVIDER_POSTAL_LOCATOR - Get provider address
+ * 7. TMP_S_PROVIDER_TELE_LOCATOR_OFFICE - Get provider office telephone contact
+ * 8. TMP_S_PROVIDER_TELE_LOCATOR_CELL -  Provider Cell telephone contact
+ * 9. TMP_S_PROVIDER_LOCATOR - Join TMP_S_PROVIDER_TELE_LOCATOR_OFFICE,
+ * TMP_S_PROVIDER_TELE_LOCATOR_CELL, TMP_S_PROVIDER_POSTAL_LOCATOR
+ * 10. TMP_S_PROVIDER_QEC_ENTITY_ID - Get provider of entity type `QEC`
+ * 11. TMP_PRN_ENTITY_ID - Get provider of entity type `PRN`
+ * 12. TMP_S_PROVIDER_FINAL - Join TMP_S_PROVIDER_WITH_NM (step 5),
+ * TMP_S_PROVIDER_LOCATOR (step 9), TMP_S_PROVIDER_QEC_ENTITY_ID (step 10),
+ * TMP_PRN_ENTITY_ID (step 11)
+ * 13. S_PROVIDER - Copy TMP_S_PROVIDER_FINAL to S_PROVIDER
+ * ---------
+ * 14. TMP_L_PROVIDER_N
+ * 15. TMP_L_PROVIDER_E
+ * ---
+ * 16. TMP_D_PROVIDER_N- Join S_PROVIDER, TMP_L_PROVIDER_N
+ * 17. TMP_D_PROVIDER_E - Join S_PROVIDER, TMP_D_PROVIDER_E
+ * 18. Update D_PROVIDER - Update from TMP_D_PROVIDER_E
+ * 19. Insert into D_PROVIDER - from TMP_D_PROVIDER_N
+ ***/

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/utils/StreamsSerdes.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/utils/StreamsSerdes.java
@@ -1,13 +1,14 @@
 package gov.cdc.etldatapipeline.changedata.utils;
 
-import gov.cdc.etldatapipeline.changedata.model.odse.NbsPage;
-import gov.cdc.etldatapipeline.changedata.model.odse.CtContact;
-import gov.cdc.etldatapipeline.changedata.model.odse.Participation;
-import gov.cdc.etldatapipeline.changedata.model.odse.Person;
+import com.fasterxml.jackson.core.type.TypeReference;
+import gov.cdc.etldatapipeline.changedata.model.odse.*;
+import gov.cdc.etldatapipeline.changedata.model.dto.Provider;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.List;
 
 public class StreamsSerdes extends Serdes {
 
@@ -17,6 +18,14 @@ public class StreamsSerdes extends Serdes {
 
     public static Serde<Person> PersonSerde() {
         return new PersonSerde();
+    }
+
+    public static Serde<Provider> ProviderSerde() {
+        return new ProviderSerde();
+    }
+
+    public static Serde<List<String>> StringListSerde() {
+        return new StringListSerde();
     }
 
     public static Serde<Participation> ParticipationSerde() {
@@ -41,6 +50,20 @@ public class StreamsSerdes extends Serdes {
         }
     }
 
+    public static final class ProviderSerde extends WrapperSerde<Provider> {
+        public ProviderSerde() {
+            super(new JsonSerializer<>(),
+                    new JsonDeserializer<>(Provider.class, false));
+        }
+    }
+
+    public static final class StringListSerde extends WrapperSerde<List<String>> {
+        public StringListSerde() {
+            super(new JsonSerializer<>(), new JsonDeserializer<>(new TypeReference<>() {
+            }, false));
+        }
+    }
+
     public static final class ParticipationSerde extends WrapperSerde<Participation> {
         public ParticipationSerde() {
             super(new JsonSerializer<>(),
@@ -50,7 +73,8 @@ public class StreamsSerdes extends Serdes {
 
     public static final class CtContactSerde extends WrapperSerde<CtContact> {
         public CtContactSerde() {
-            super(new JsonSerializer<>(), new JsonDeserializer<>(CtContact.class, false));
+            super(new JsonSerializer<>(),
+                    new JsonDeserializer<>(CtContact.class, false));
         }
     }
 }

--- a/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/utils/UtilHelper.java
+++ b/etl-data-pipeline/src/main/java/gov/cdc/etldatapipeline/changedata/utils/UtilHelper.java
@@ -1,6 +1,7 @@
 package gov.cdc.etldatapipeline.changedata.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cdc.etldatapipeline.changedata.model.odse.DebeziumMetadata;
@@ -15,7 +16,7 @@ import org.springframework.util.Assert;
 public class UtilHelper {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static UtilHelper utilHelper = null;
+    private static final UtilHelper utilHelper = null;
 
     private UtilHelper() {
     }
@@ -43,6 +44,36 @@ public class UtilHelper {
             T dMetadata = objectMapper.convertValue(node, type);
             dMetadata.setTs_ms(objectMapper.readTree(jsonString).at("/payload/ts_ms").asLong());
             dMetadata.setOp(objectMapper.readTree(jsonString).at("/payload/op").asText());
+            return dMetadata;
+        } catch (JsonProcessingException e) {
+            log.error("JsonProcessingException: ", e);
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public <T extends DebeziumMetadata> T deserializePayload(
+            String jsonString, String nodeName, JavaType type) {
+        try {
+            if(jsonString == null) return null;
+            JsonNode node = objectMapper.readTree(jsonString).at(nodeName);
+            if(node == null) return null;
+            T dMetadata = objectMapper.readValue(node.textValue(), type);
+            dMetadata.setTs_ms(objectMapper.readTree(jsonString).at("/payload/ts_ms").asLong());
+            dMetadata.setOp(objectMapper.readTree(jsonString).at("/payload/op").asText());
+            return dMetadata;
+        } catch (JsonProcessingException e) {
+            log.error("JsonProcessingException: ", e);
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public <T> T deserializePayload(
+            String jsonString, JavaType type) {
+        try {
+            if(jsonString == null) return null;
+            T dMetadata = objectMapper.readValue(jsonString, type);
             return dMetadata;
         } catch (JsonProcessingException e) {
             log.error("JsonProcessingException: ", e);

--- a/etl-data-pipeline/src/main/resources/application.properties
+++ b/etl-data-pipeline/src/main/resources/application.properties
@@ -7,14 +7,18 @@ logging.level.gov.cdc.etldatapipeline=DEBUG
 # Apache Kafka Configurations
 spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.streams.application-id=debezium-cdc-consumer-app-1
+spring.kafka.producer.key-serializer=org.springframework.kafka.support.serializer.StringOrBytesSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
 
 # Database
-spring.datasource.url=jdbc:sqlserver://cdc-nbs-alabama-rds-mssql.czya31goozkz.us-east-1.rds.amazonaws.com:1433;databaseName=rdb_test;encrypt=true;trustServerCertificate=true;
-spring.datasource.username=admin
-spring.datasource.password=${RDB_PASSWORD:}
+spring.datasource.url=${DB_URL:jdbc:sqlserver://localhost:1433;databaseName=NBS_ODSE;encrypt=true;trustServerCertificate=true;}
+spring.datasource.username=${DB_USERNAME:sa}
+spring.datasource.password=${DB_PASSWORD:fake.fake.fake.1234}
 
 # Apache Kafka Topic Names
 spring.kafka.stream.input.nbs-pages.topic-name=cdc.nbs_odse.dbo.NBS_page
+spring.kafka.stream.input.provider.topic-name=cdc.nbs_odse.dbo.Provider
+spring.kafka.stream.input.provider.output-topic-name=cdc.nbs_odse.dbo.Provider.output
 spring.kafka.stream.input.person.topic-name=cdc.nbs_odse.dbo.Person
 spring.kafka.stream.input.participation.topic-name=cdc.nbs_odse.dbo.Participation
 spring.kafka.stream.input.ct-contact.topic-name=cdc.nbs_odse.dbo.CT_contact


### PR DESCRIPTION
**CNDIT-1024** : Convert Provider to kafka streams

**ChangeLog**:
Add support for processing any change to the Provider module in ODSE:
1. Accept list of PersonIds from input Kafka topic (cdc.nbs_odse.dbo.Provider)
2. Process the incoming PersonIds into KafkaStream
3. For each of the Person Id, fetch the corresponding Provider data
4. Write the provider data to aggregated provider Kafka topic (cdc.nbs_odse.dbo.Provider.output)

**DataFlow**:
ODSE.Person data event -> Kafka topic (cdc.nbs_odse.dbo.Provider) -> NEDSS-DataAcces Java Kafka Streaming Service -> AggregatedKafka topic (cdc.nbs_odse.dbo.Provider.output)

**Usage**: To trigger the Provider use case:
```
 curl --location 'http://localhost:8090/provider' \
  --header 'Content-Type: application/json' \
  --data '[10000001,10000008]'
```