### PR TITLE
Update provider service using gap analysis

### DIFF
--- a/data-reporting-service/person-service/src/main/java/gov/cdc/etldatapipeline/person/model/dto/provider/ProviderReporting.java
+++ b/data-reporting-service/person-service/src/main/java/gov/cdc/etldatapipeline/person/model/dto/provider/ProviderReporting.java
@@ -43,7 +43,7 @@ public class ProviderReporting implements PersonExtendedProps, DataRequiredField
     @JsonProperty("name_prefix")
     private String nmPrefix;
     @JsonProperty("name_degree")
-    private String nameDegree;
+    private String nmDegree;
 
     //Address
     @JsonProperty("street_address_1")

--- a/data-reporting-service/person-service/src/test/java/gov/cdc/etldatapipeline/person/ProviderDataPostProcessingTests.java
+++ b/data-reporting-service/person-service/src/test/java/gov/cdc/etldatapipeline/person/ProviderDataPostProcessingTests.java
@@ -37,6 +37,7 @@ public class ProviderDataPostProcessingTests {
                 pf.getMiddleNm(),
                 pf.getFirstNm(),
                 pf.getNmSuffix(),
+                pf.getNmDegree(),
                 pf.getStreetAddress1(),
                 pf.getStreetAddress2(),
                 pf.getCity(),
@@ -61,6 +62,7 @@ public class ProviderDataPostProcessingTests {
                 "Js",
                 "Suurma",
                 "Jr",
+                "MD",
                 "123 Main St.",
                 "",
                 "Atlanta",
@@ -95,7 +97,8 @@ public class ProviderDataPostProcessingTests {
                 p.getLastNm(),
                 p.getMiddleNm(),
                 p.getFirstNm(),
-                p.getNmSuffix());
+                p.getNmSuffix(),
+                p.getNmDegree());
         // Process the respective field json to PatientProviderProvider fields
         ProviderReporting pf = (ProviderReporting) tx.processData(prov, PersonType.PROVIDER_REPORTING).getPayload();
 
@@ -103,7 +106,8 @@ public class ProviderDataPostProcessingTests {
                 "Singgh",
                 "Js",
                 "Suurma",
-                "Jr");
+                "Jr",
+                "MD");
         // Validate the PatientProvider field processing
         Assertions.assertEquals(expected, pDetailsFn.apply(pf));
     }

--- a/data-reporting-service/person-service/src/test/java/gov/cdc/etldatapipeline/person/config/PersonSvcYmlPropertiesTest.java
+++ b/data-reporting-service/person-service/src/test/java/gov/cdc/etldatapipeline/person/config/PersonSvcYmlPropertiesTest.java
@@ -23,9 +23,9 @@ public class PersonSvcYmlPropertiesTest {
     void whenBindingYMLConfigFile_thenAllFieldsAreSet() {
         Assertions.assertEquals("nbs_default", kafkaConfig.getDefaultDataTopicName());
         Assertions.assertEquals("nbs_Person", kafkaConfig.getPersonTopicName());
-        Assertions.assertEquals("nrt_patient_elastic", kafkaConfig.getPatientElasticSearchTopic());
+        Assertions.assertEquals("elastic_nrt_patient", kafkaConfig.getPatientElasticSearchTopic());
         Assertions.assertEquals("nrt_patient", kafkaConfig.getPatientReportingTopic());
-        Assertions.assertEquals("nrt_provider_elastic", kafkaConfig.getProviderElasticSearchTopic());
+        Assertions.assertEquals("elastic_nrt_provider", kafkaConfig.getProviderElasticSearchTopic());
         Assertions.assertEquals("nrt_provider", kafkaConfig.getProviderReportingTopic());
     }
 

--- a/data-reporting-service/person-service/src/test/resources/rawDataFiles/person/PersonName.json
+++ b/data-reporting-service/person-service/src/test/resources/rawDataFiles/person/PersonName.json
@@ -18,7 +18,7 @@
     "firstNmSndx": "S750",
     "nm_use_cd": "L",
     "nmSuffix": "Jr",
-    "nmDegree": null,
+    "nmDegree": "MD",
     "pn_person_uid": 10000009
   },
   {

--- a/data-reporting-service/person-service/src/test/resources/rawDataFiles/provider/ProviderElasticSearch.json
+++ b/data-reporting-service/person-service/src/test/resources/rawDataFiles/provider/ProviderElasticSearch.json
@@ -490,7 +490,7 @@
     "lastNm": "Singgh",
     "nmSuffix": "Jr",
     "nmPrefix": null,
-    "nmdegree": null,
+    "nmdegree": "MD",
     "person_name_seq": null,
     "streetAddr1": "123 Main St.",
     "streetAddr2": "",

--- a/data-reporting-service/person-service/src/test/resources/rawDataFiles/provider/ProviderReporting.json
+++ b/data-reporting-service/person-service/src/test/resources/rawDataFiles/provider/ProviderReporting.json
@@ -212,7 +212,7 @@
     "last_name": "Singgh",
     "name_suffix": "Jr",
     "name_prefix": null,
-    "name_degree": null,
+    "name_degree": "MD",
     "street_address_1": "123 Main St.",
     "street_address_2": ""
   }


### PR DESCRIPTION
## Description ##
Update Provider model mapping to point to pull correct values for `name_degree` column in RDB’s `nrt_provider`. This will align the value mapping between `nrt_provider` and `D_Provider`.

- **ProviderReporting.java**: corrected field name to fix name_degree mapping
- **ProviderDataPostProcessingTests.java**: updated unit tests
- **PersonName.json**, **ProviderElasticSearch.json**, **ProviderReporting.json**: modified payloads for unit tests

## Ticket ##
[CNDIT-1261 RTR - Update provider service using gap analysis/bug](https://cdc-nbs.atlassian.net/browse/CNDIT-1261)