### PR TITLE
CNDIT-1152: Unit tests for Observation Service

### DIFF
--- a/data-reporting-service/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/config/KafkaConfig.java
+++ b/data-reporting-service/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/config/KafkaConfig.java
@@ -3,11 +3,13 @@ package gov.cdc.etldatapipeline.observation.config;
 import lombok.Getter;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
 
 @Configuration
+@ConfigurationProperties
 @Getter
 public class KafkaConfig {
     @Value("${spring.kafka.stream.input.observation.topic-name}")

--- a/data-reporting-service/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/service/ObservationService.java
+++ b/data-reporting-service/observation-service/src/main/java/gov/cdc/etldatapipeline/observation/service/ObservationService.java
@@ -9,6 +9,7 @@ import gov.cdc.etldatapipeline.observation.repository.model.Observation;
 import gov.cdc.etldatapipeline.observation.repository.model.ObservationTransformed;
 import gov.cdc.etldatapipeline.observation.util.ProcessObservationDataUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Service;
 import java.util.Optional;
 
 @Service
+@Setter
 @RequiredArgsConstructor
 public class ObservationService {
     private static final Logger logger = LoggerFactory.getLogger(ObservationService.class);

--- a/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/ObservationDataProcessTests.java
+++ b/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/ObservationDataProcessTests.java
@@ -1,0 +1,63 @@
+package gov.cdc.etldatapipeline.observation;
+
+import gov.cdc.etldatapipeline.observation.repository.model.Observation;
+import gov.cdc.etldatapipeline.observation.repository.model.ObservationTransformed;
+import gov.cdc.etldatapipeline.observation.util.ProcessObservationDataUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static gov.cdc.etldatapipeline.observation.TestUtils.readFileData;
+
+public class ObservationDataProcessTests {
+    private static final String FILE_PREFIX = "rawDataFiles/";
+    ProcessObservationDataUtil util = new ProcessObservationDataUtil();
+
+    @Test
+    public void consolidatedDataTransformationTest() {
+        Observation observation = new Observation();
+        observation.setActUid(100000001L);
+        observation.setObsDomainCdSt1("Order");
+
+        observation.setPersonParticipations(readFileData(FILE_PREFIX + "PersonParticipations.json"));
+        observation.setOrganizationParticipations(readFileData(FILE_PREFIX + "OrganizationParticipations.json"));
+        observation.setMaterialParticipations(readFileData(FILE_PREFIX + "MaterialParticipations.json"));
+        observation.setFollowupObservations(readFileData(FILE_PREFIX + "FollowupObservations.json"));
+
+        ObservationTransformed observationTransformed = util.transformObservationData(observation);
+
+        Long patId = observationTransformed.getPatientId();
+        Long ordererId = observationTransformed.getOrderingPersonId();
+        Long authorOrgId = observationTransformed.getAuthorOrganizationId();
+        Long ordererOrgId = observationTransformed.getOrderingOrganizationId();
+        Long performerOrgId = observationTransformed.getPerformingOrganizationId();
+        Long materialId = observationTransformed.getMaterialId();
+        Long resultObsUid = observationTransformed.getResultObservationUid();
+
+
+        Assertions.assertEquals(10000055L, ordererId);
+        Assertions.assertEquals(10000066L, patId);
+        Assertions.assertEquals(34567890L, authorOrgId);
+        Assertions.assertEquals(23456789L, ordererOrgId);
+        Assertions.assertNull(performerOrgId);
+        Assertions.assertEquals(10000005L, materialId);
+        Assertions.assertEquals(56789012L, resultObsUid);
+    }
+
+    @Test
+    public void organizationDataTransformationTest() {
+        Observation observation = new Observation();
+        observation.setActUid(100000001L);
+        observation.setObsDomainCdSt1("Result");
+
+        observation.setOrganizationParticipations(readFileData(FILE_PREFIX + "OrganizationParticipations.json"));
+
+        ObservationTransformed observationTransformed = util.transformObservationData(observation);
+        Long authorOrgId = observationTransformed.getAuthorOrganizationId();
+        Long ordererOrgId = observationTransformed.getOrderingOrganizationId();
+        Long performerOrgId = observationTransformed.getPerformingOrganizationId();
+
+        Assertions.assertNull(authorOrgId);
+        Assertions.assertNull(ordererOrgId);
+        Assertions.assertEquals(45678901L, performerOrgId);
+    }
+}

--- a/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/ObservationServiceApplicationTests.java
+++ b/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/ObservationServiceApplicationTests.java
@@ -1,16 +1,39 @@
-//package gov.cdc.etldatapipeline.observation;
-//
-//import org.junit.jupiter.api.Test;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//@SpringBootTest
-//class ObservationServiceApplicationTests {
-//
-//    @Test
-//    void contextLoads() {
-//    }
-//
-//}
+package gov.cdc.etldatapipeline.observation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest
+class ObservationServiceApplicationTests {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void contextLoads() {
+        assertNotNull(context, "The application context should not be null");
+    }
+
+    @Configuration
+    static class TestConfiguration {
+
+        @Bean
+        @Primary
+        public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+            return mock(LocalContainerEntityManagerFactoryBean.class);
+        }
+    }
+
+}
 
 
 //--DA_LOG_PATH="logs" --DB_ODSE="NBS_ODSE" --DB_PASSWORD="ods" --DB_URL="cdc-nbs-alabama-rds-mssql.czya31goozkz.us-east-1.rds.amazonaws.com" --DB_USERNAME="nbs_ods" --KAFKA_BOOTSTRAP_SERVER="localhost:9092"

--- a/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/TestUtils.java
+++ b/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/TestUtils.java
@@ -1,0 +1,20 @@
+package gov.cdc.etldatapipeline.observation;
+
+import org.apache.commons.io.FileUtils;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class TestUtils {
+
+    public static String readFileData(String fileName) {
+        try {
+            return FileUtils.readFileToString(
+                    new ClassPathResource(fileName).getFile(),
+                    Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new RuntimeException("File Read failed : " + fileName);
+        }
+    }
+}

--- a/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/config/ObservationSvcConfigTest.java
+++ b/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/config/ObservationSvcConfigTest.java
@@ -1,0 +1,38 @@
+package gov.cdc.etldatapipeline.observation.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
+@EnableConfigurationProperties(value = KafkaConfig.class)
+@ActiveProfiles("test")
+public class ObservationSvcConfigTest {
+
+    @Autowired
+    private KafkaConfig kafkaConfig;
+
+    @Test
+    void testBindingYMLConfigFile_SetsAllFields() {
+        Assertions.assertEquals("cdc.nbs_odse.dbo.Observation", kafkaConfig.getObservationTopicName());
+        Assertions.assertEquals("cdc.nbs_odse.dbo.Observation.output", kafkaConfig.getObservationAggregateTopicName());
+        Assertions.assertEquals("cdc.nbs_odse.dbo.Observation.output-transformed", kafkaConfig.getObservationTransformedOutputTopicName());
+    }
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public KafkaConfig kafkaConfig() {
+            return new KafkaConfig();
+        }
+    }
+}

--- a/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/controller/ObservationControllerTest.java
+++ b/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/controller/ObservationControllerTest.java
@@ -1,0 +1,46 @@
+package gov.cdc.etldatapipeline.observation.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import gov.cdc.etldatapipeline.observation.service.KafkaProducerService;
+
+public class ObservationControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private KafkaProducerService kafkaProducerService;
+
+    @InjectMocks
+    private ObservationController observationController;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(observationController).build();
+    }
+
+    @Test
+    public void publishMessageToKafkaTest() throws Exception {
+        String jsonData = "{\"key\":\"value\"}";
+
+        mockMvc.perform(post("/publish")
+                        .contentType("application/json")
+                        .content(jsonData))
+                .andExpect(status().isOk());
+
+        verify(kafkaProducerService).sendMessage(eq("cdc.nbs_odse.dbo.Observation"), anyString());
+    }
+}

--- a/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/service/KafkaProducerServiceTest.java
+++ b/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/service/KafkaProducerServiceTest.java
@@ -1,0 +1,44 @@
+package gov.cdc.etldatapipeline.observation.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.kafka.core.KafkaTemplate;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KafkaProducerServiceTest {
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @InjectMocks
+    private KafkaProducerService kafkaProducerService;
+
+    @Captor
+    private ArgumentCaptor<String> topicCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> messageCaptor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testSendMessage() {
+        String topicName = "test-topic";
+        String jsonData = "{\"key\":\"value\"}";
+
+        kafkaProducerService.sendMessage(topicName, jsonData);
+
+        verify(kafkaTemplate).send(topicCaptor.capture(), messageCaptor.capture());
+        assertEquals(topicName, topicCaptor.getValue());
+        assertEquals(jsonData, messageCaptor.getValue());
+    }
+}

--- a/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/service/ObservationServiceTest.java
+++ b/data-reporting-service/observation-service/src/test/java/gov/cdc/etldatapipeline/observation/service/ObservationServiceTest.java
@@ -1,76 +1,116 @@
-//package gov.cdc.etldatapipeline.observation.service;
-//
-//import com.fasterxml.jackson.databind.JsonNode;
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import gov.cdc.etldatapipeline.observation.repository.IObservationRepository;
-//import gov.cdc.etldatapipeline.observation.repository.model.Observation;
-//import org.apache.kafka.common.serialization.Serdes;
-//import org.apache.kafka.streams.StreamsBuilder;
-//import org.apache.kafka.streams.kstream.Consumed;
-//import org.apache.kafka.streams.kstream.KStream;
-//import org.apache.kafka.streams.kstream.Produced;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//
-//import java.util.Optional;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
-//
-//class ObservationServiceTest {
-//
-//    @Mock
-//    private IObservationRepository observationRepository;
-//
-//    @InjectMocks
-//    private ObservationService observationService;
-//
-//    @BeforeEach
-//    void setUp() {
-//        MockitoAnnotations.openMocks(this);
-//    }
-//
-//    @Test
-//    void testProcessMessage() throws Exception {
-//        // Mocked input data
-//        String observationUid = "123456789";
-//        String inputJson = "{\"payload\": {\"after\": {\"observation_uid\": \"" + observationUid + "\"}}}";
-//
-//        // Mocked observation
-//        Observation observation = new Observation();
-//        observation.setId(Long.valueOf(observationUid));
-//
-//        // Mocked ObjectMapper
-//        ObjectMapper objectMapper = mock(ObjectMapper.class);
-//        JsonNode jsonNode = objectMapper.readTree(inputJson);
-//        when(objectMapper.readTree(any(String.class))).thenReturn(jsonNode);
-//        when(objectMapper.writeValueAsString(any())).thenReturn("mockedObservationJson");
-//
-//        // Mocked observationRepository behavior
-//        when(observationRepository.computeObservations(eq(observationUid))).thenReturn(Optional.of(observation));
-//
-//        StreamsBuilder streamsBuilder = mock(StreamsBuilder.class);
-//        KStream<String, String> mockKStream = mock(KStream.class);
-//
-//        // Use thenAnswer() instead of thenReturn()
-//        when(streamsBuilder.stream(anyString(), any())).thenAnswer(invocation -> {
-//            String topicName = invocation.getArgument(0);
-//            Consumed<String, String> consumed = invocation.getArgument(1);
-//            // Return the mocked KStream
-//            return mockKStream;
-//        });
-//        // Mocked Consumed and Produced
-//        Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
-//        Produced<String, String> produced = Produced.with(Serdes.String(), Serdes.String());
-//
-//        // Test the method
-//        observationService.processMessage(streamsBuilder);
-//
-//        // Verify that expected methods were called
-//        verify(streamsBuilder).stream(eq(observationService.observationTopicOutput), eq(consumed));
-//        verify(observationRepository).computeObservations(eq(observationUid));
-//    }
-//}
+package gov.cdc.etldatapipeline.observation.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cdc.etldatapipeline.observation.TestUtils;
+import gov.cdc.etldatapipeline.observation.repository.IObservationRepository;
+import gov.cdc.etldatapipeline.observation.repository.model.Observation;
+import gov.cdc.etldatapipeline.observation.util.ProcessObservationDataUtil;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class ObservationServiceTest {
+
+    @Mock
+    private IObservationRepository observationRepository;
+
+    @Mock KafkaTemplate<String, String> kafkaTemplate;
+
+    @Captor
+    private ArgumentCaptor<String> topicCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> messageCaptor;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    ProcessObservationDataUtil transformer = new ProcessObservationDataUtil();
+
+    @Test
+    void testProcessMessage() {
+        String observationTopic = "Observation";
+        String observationTopicOutput = "ObservationOutput";
+        String observationTopicOutputTransformed = "ObservationOutputTransformed";
+
+        // Mocked input data
+        Long observationUid = 123456789L;
+        String obsDomainCdSt = "Order";
+        String payload = "{\"payload\": {\"after\": {\"observation_uid\": \"" + observationUid + "\"}}}";
+
+        Observation observation = constructObservation(observationUid, obsDomainCdSt);
+        when(observationRepository.computeObservations(eq(String.valueOf(observationUid)))).thenReturn(Optional.of(observation));
+
+        final String expectedTransformed = transformer.transformObservationData(observation).toString();
+
+        validateData(observationTopic, observationTopicOutput,
+                observationTopicOutputTransformed, payload, observationUid);
+
+        verify(kafkaTemplate).send(topicCaptor.capture(), messageCaptor.capture());
+        assertEquals(observationTopicOutputTransformed, topicCaptor.getValue());
+        assertEquals(expectedTransformed, messageCaptor.getValue());
+        verify(observationRepository).computeObservations(eq(String.valueOf(observationUid)));
+    }
+
+    private Observation constructObservation(Long observationUid, String obsDomainCdSt1) {
+        String filePathPrefix = "rawDataFiles/";
+        Observation observation = new Observation();
+        observation.setId(observationUid);
+        observation.setObsDomainCdSt1(obsDomainCdSt1);
+        observation.setPersonParticipations(TestUtils.readFileData(filePathPrefix + "PersonParticipations.json"));
+        return observation;
+    }
+
+    private void validateData(String inputTopicName, String outputTopicName, String transformedTopicName,
+                              String payload, Long expectedUid) {
+        StreamsBuilder builder = new StreamsBuilder();
+        final var observationService = getObservationService(inputTopicName, outputTopicName, transformedTopicName);
+        observationService.processMessage(builder);
+
+        TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), new Properties());
+        final Serde<String> serdeString = Serdes.String();
+        TestInputTopic<String, String> inputTopic = testDriver.createInputTopic(
+                inputTopicName, serdeString.serializer(), serdeString.serializer());
+
+        TestOutputTopic<String, String> outputTopic = testDriver.createOutputTopic(
+                outputTopicName, serdeString.deserializer(), serdeString.deserializer());
+
+        inputTopic.pipeInput("100000001", payload);
+        KeyValue<String, String> result = outputTopic.readKeyValue();
+        try {
+            Observation actual = objectMapper.readValue(result.value, Observation.class);
+            assertEquals(expectedUid, actual.getId());
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        testDriver.close();
+    }
+
+    private ObservationService getObservationService(String inputTopicName, String outputTopicName, String transformedTopicName) {
+        ObservationService observationService = new ObservationService(observationRepository, kafkaTemplate, new ProcessObservationDataUtil());
+        observationService.setObservationTopic(inputTopicName);
+        observationService.setObservationTopicOutput(outputTopicName);
+        observationService.setObservationTopicOutputTransformed(transformedTopicName);
+        return observationService;
+    }
+
+
+}

--- a/data-reporting-service/observation-service/src/test/resources/rawDataFiles/FollowupObservations.json
+++ b/data-reporting-service/observation-service/src/test/resources/rawDataFiles/FollowupObservations.json
@@ -1,0 +1,17 @@
+[
+  {
+    "cd": "5199-5",
+    "cd_desc_txt": "HEPATITIS C VIRUS AB SIGNAL\/CUTOFF",
+    "domain_cd_st_1": "Result",
+    "status_cd": "D",
+    "alt_cd": null,
+    "alt_cd_desc_txt": null,
+    "alt_cd_system_cd": null,
+    "display_name": "Positive",
+    "ovc_code": "10828004",
+    "ovc_alt_cd": null,
+    "ovc_alt_cd_desc_txt": null,
+    "ovc_alt_cd_system_cd": null,
+    "result_observation_uid": 56789012
+  }
+]

--- a/data-reporting-service/observation-service/src/test/resources/rawDataFiles/MaterialParticipations.json
+++ b/data-reporting-service/observation-service/src/test/resources/rawDataFiles/MaterialParticipations.json
@@ -1,0 +1,13 @@
+[
+  {
+    "act_uid": 100000003,
+    "type_cd": "SPC",
+    "entity_id": 10000005,
+    "subject_class_cd": "MAT",
+    "record_status": "ACTIVE",
+    "type_desc_txt": "Specimen",
+    "last_change_time": "2024-01-01T00:00:00.000",
+    "material_cd": "UNK",
+    "material_cd_desc_txt": "Unknown"
+  }
+]

--- a/data-reporting-service/observation-service/src/test/resources/rawDataFiles/OrganizationParticipations.json
+++ b/data-reporting-service/observation-service/src/test/resources/rawDataFiles/OrganizationParticipations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "act_uid": 10000003,
+    "type_cd": "AUT",
+    "entity_id": 34567890,
+    "subject_class_cd": "ORG",
+    "record_status": "ACTIVE",
+    "type_desc_txt": "Author",
+    "last_change_time": "2024-01-01T00:00:00.000",
+    "name": "LABCORP",
+    "org_last_change_time": "2018-03-15T00:00:00.000"
+  },
+  {
+    "act_uid": 10000003,
+    "type_cd": "ORD",
+    "entity_id": 23456789,
+    "subject_class_cd": "ORG",
+    "record_status": "ACTIVE",
+    "type_desc_txt": "Orderer",
+    "last_change_time": "2024-01-01T00:00:00.000",
+    "name": "Mount-Auburn Health",
+    "org_last_change_time": "2011-09-13T00:00:00.000"
+  },
+  {
+    "act_uid": 10000003,
+    "type_cd": "PRF",
+    "entity_id": 45678901,
+    "subject_class_cd": "ORG",
+    "record_status": "ACTIVE",
+    "type_desc_txt": "Performer",
+    "last_change_time": "2024-01-01T00:00:00.000",
+    "name": "Mount-Auburn Health",
+    "org_last_change_time": "2011-09-13T00:00:00.000"
+  }
+]

--- a/data-reporting-service/observation-service/src/test/resources/rawDataFiles/PersonParticipations.json
+++ b/data-reporting-service/observation-service/src/test/resources/rawDataFiles/PersonParticipations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "act_uid": 10000003,
+    "type_cd": "ORD",
+    "entity_id": 10000055,
+    "subject_class_cd": "PSN",
+    "participation_record_status": "ACTIVE",
+    "participation_last_change_time": "2024-01-25T00:00:00.000",
+    "type_desc_txt": "Orderer",
+    "first_name": "Din",
+    "last_name": "Djarin",
+    "local_id": "PSN10000000AL01",
+    "birth_time": null,
+    "curr_sex_cd": null,
+    "person_cd": "PRV",
+    "person_parent_uid": 12345678,
+    "person_record_status": "ACTIVE",
+    "person_last_chg_time": "2009-11-01T00:00:00.000"
+  },
+  {
+    "act_uid": 10000003,
+    "type_cd": "PATSBJ",
+    "entity_id": 10000066,
+    "subject_class_cd": "PSN",
+    "participation_record_status": "ACTIVE",
+    "participation_last_change_time": null,
+    "type_desc_txt": "Patient Subject",
+    "first_name": "Boba",
+    "last_name": "Fett",
+    "local_id": "PSN40000004AL01",
+    "birth_time": "1990-03-13T00:00:00",
+    "curr_sex_cd": "M",
+    "person_cd": "PAT",
+    "person_parent_uid": 23456789,
+    "person_record_status": "ACTIVE",
+    "person_last_chg_time": "2024-01-01T00:00:00.000"
+  }
+]


### PR DESCRIPTION
## Description ##
Unit tests for Observation Service with 96% of methods coverage

- **ObservationServiceTest**: KafkaStreams service test, including `processMessage`, `kafkaTemplate.send` and data transformation
- **ObservationDataProcessTests**: consolidated and organzation specific data transformation tests
- **ObservationControllerTest**: controller test
- **ObservationSvcConfigTest**: configuration test
- other less important tests, utils and json inputs

## Ticket ##
[CNDIT-1152 - Unit tests for Observation Service](https://cdc-nbs.atlassian.net/browse/CNDIT-1152)