### PR TITLE
CNDIT-1360: Identify and fix pre-processing gaps for notifications post-processing

### DIFF
--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/config/KafkaConfig.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/config/KafkaConfig.java
@@ -22,9 +22,6 @@ public class KafkaConfig {
     @Value("${spring.kafka.stream.output.investigation.topic-name-confirmation}")
     public String investigationConfirmationOutputTopicName;
 
-    @Value("${spring.kafka.stream.output.investigation.topic-name-notification}")
-    public String investigationNotificationOutputTopicName;
-
     @Value("${spring.kafka.stream.output.investigation.topic-name-observation}")
     public String investigationObservationOutputTopicName;
 
@@ -44,11 +41,6 @@ public class KafkaConfig {
     @Bean
     public NewTopic createInvestigationConfirmationOutputTopic() {
         return TopicBuilder.name(investigationConfirmationOutputTopicName).build();
-    }
-
-    @Bean
-    public NewTopic createInvestigationNotificationOutputTopic() {
-        return TopicBuilder.name(investigationNotificationOutputTopicName).build();
     }
 
     @Bean

--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationNotification.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationNotification.java
@@ -1,9 +1,0 @@
-package gov.cdc.etldatapipeline.investigation.repository.model.dto;
-
-import lombok.Data;
-
-@Data
-public class InvestigationNotification {
-    private Long publicHealthCaseUid;
-    private Long notificationId;
-}

--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationNotifications.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationNotifications.java
@@ -100,6 +100,14 @@ public class InvestigationNotifications {
 
     @JsonProperty("local_patient_uid")
     @Column(name = "local_patient_uid")
-    private String localPatientUid;
+    private Long localPatientUid;
+
+    @JsonProperty("condition_cd")
+    @Column(name = "condition_cd")
+    private String conditionCd;
+
+    @JsonProperty("condition_desc")
+    @Column(name = "condition_desc")
+    private String conditionDesc;
 }
 

--- a/data-reporting-service/investigation-service/src/main/resources/application.yaml
+++ b/data-reporting-service/investigation-service/src/main/resources/application.yaml
@@ -9,7 +9,6 @@ spring:
           topic-name-reporting: nrt_investigation
           topic-name-es: elastic_search_investigation
           topic-name-confirmation: nrt_investigation_confirmation
-          topic-name-notification: nrt_investigation_notification
           topic-name-observation: nrt_investigation_observation
           topic-name-notifications: nrt_notifications
     streams:

--- a/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/config/InvestigationSvcConfigTest.java
+++ b/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/config/InvestigationSvcConfigTest.java
@@ -26,7 +26,6 @@ public class InvestigationSvcConfigTest {
         Assertions.assertEquals("nbs_Public_health_case", kafkaConfig.getInvestigationInputTopicName());
         Assertions.assertEquals("nrt_investigation", kafkaConfig.getInvestigationReportingOutputTopicName());
         Assertions.assertEquals("nrt_investigation_confirmation", kafkaConfig.getInvestigationConfirmationOutputTopicName());
-        Assertions.assertEquals("nrt_investigation_notification", kafkaConfig.getInvestigationNotificationOutputTopicName());
         Assertions.assertEquals("nrt_investigation_observation", kafkaConfig.getInvestigationObservationOutputTopicName());
         Assertions.assertEquals("nrt_notifications", kafkaConfig.getNotificationsOutputTopicName());
     }

--- a/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/service/InvestigationServiceTest.java
+++ b/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/service/InvestigationServiceTest.java
@@ -92,7 +92,7 @@ class InvestigationServiceTest {
         String expectedKey = jsonGenerator.generateStringJson(investigationKey);
         String expectedValue = jsonGenerator.generateStringJson(reportingModel);
 
-        verify(kafkaTemplate, times(5)).send(topicCaptor.capture(), keyCaptor.capture(), messageCaptor.capture());
+        verify(kafkaTemplate, times(4)).send(topicCaptor.capture(), keyCaptor.capture(), messageCaptor.capture());
         assertEquals(outputTopicName, topicCaptor.getValue());
         assertEquals(expectedKey, keyCaptor.getValue());
         assertEquals(expectedValue, messageCaptor.getValue());

--- a/data-reporting-service/investigation-service/src/test/resources/rawDataFiles/InvestigationNotifications.json
+++ b/data-reporting-service/investigation-service/src/test/resources/rawDataFiles/InvestigationNotifications.json
@@ -23,6 +23,8 @@
     "notif_last_chg_user_name": "Zor-El, Kara",
     "notif_last_chg_time": "2024-05-29T16:05:44.523",
     "local_patient_id": "ABC7539512AB01",
-    "local_patient_uid": 75395128
+    "local_patient_uid": 75395128,
+    "condition_cd": "11065",
+    "condition_desc": "Novel Coronavirus"
   }
 ]


### PR DESCRIPTION
## Description
This PR includes fixes in Investigation pre-processing service to fill the gaps in the notifications post-processing

- Deleted `nrt_ivestigation_notification` topic and payload transformation
- The `nrt_notifications` payload completed with the `condition_cd` field required in notification post-processing
- Stored procedure `sp_nrt_notification_postprocessing` processes `nrt_notifications` to populate `Notification` and `Notification_Event` dimensions (created in Alabama db, ready for review)

## Testing
- Unit tests are corrected in accordance with the changes

## JIRA
[CNDIT-1360](https://cdc-nbs.atlassian.net/browse/CNDIT-1360)
