### PR TITLE
CNDIT-1457: Call page builder wrapper stored proc

### DIFF
--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationCaseAnswer.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationCaseAnswer.java
@@ -87,6 +87,10 @@ public class InvestigationCaseAnswer {
     @Column(name = "mask")
     private String mask;
 
+    @JsonProperty("block_nm")
+    @Column(name = "block_nm")
+    private String blockNm;
+
     @JsonProperty("question_group_seq_nbr")
     @Column(name = "question_group_seq_nbr")
     private String questionGroupSeqNbr;

--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationTransformed.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationTransformed.java
@@ -12,4 +12,5 @@ public class InvestigationTransformed {
     private String cityCountyCaseNbr;
     private String legacyCaseId;
     private Long phcInvFormId;
+    private String rdbTableNameList;
 }

--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/reporting/InvestigationReporting.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/reporting/InvestigationReporting.java
@@ -95,6 +95,7 @@ public class InvestigationReporting {
     private String cityCountyCaseNbr;
     private String legacyCaseId;
     private Long phcInvFormId;
+    private String rdbTableNameList;
     private Long addUserId;
     private String addUserName;
     private String addTime;

--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
@@ -107,5 +107,6 @@ public class InvestigationService {
         reportingModel.setCityCountyCaseNbr(investigationTransformed.getCityCountyCaseNbr());
         reportingModel.setLegacyCaseId(investigationTransformed.getLegacyCaseId());
         reportingModel.setPhcInvFormId(investigationTransformed.getPhcInvFormId());
+        reportingModel.setRdbTableNameList(investigationTransformed.getRdbTableNameList());
     }
 }

--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/util/ProcessInvestigationDataUtil.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/util/ProcessInvestigationDataUtil.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -48,7 +49,7 @@ public class ProcessInvestigationDataUtil {
         transformActIds(investigation.getActIds(), investigationTransformed, objectMapper);
         transformObservationIds(investigation.getObservationNotificationIds(), investigationTransformed, objectMapper);
         transformInvestigationConfirmationMethod(investigation.getInvestigationConfirmationMethod(), objectMapper);
-        processInvestigationPageCaseAnswer(investigation.getInvestigationCaseAnswer(), objectMapper);
+        processInvestigationPageCaseAnswer(investigation.getInvestigationCaseAnswer(), investigationTransformed, objectMapper);
         transformNotifications(investigation.getInvestigationNotifications(), objectMapper);
 
         return investigationTransformed;
@@ -254,7 +255,7 @@ public class ProcessInvestigationDataUtil {
         }
     }
 
-    private void processInvestigationPageCaseAnswer(String investigationCaseAnswer, ObjectMapper objectMapper) {
+    private void processInvestigationPageCaseAnswer(String investigationCaseAnswer, InvestigationTransformed investigationTransformed, ObjectMapper objectMapper) {
         try {
             JsonNode investigationCaseAnswerJsonArray = investigationCaseAnswer != null ? objectMapper.readTree(investigationCaseAnswer) : null;
 
@@ -275,6 +276,10 @@ public class ProcessInvestigationDataUtil {
                     investigationCaseAnswerRepository.deleteByActUid(actUid);
                     investigationCaseAnswerRepository.saveAll(investigationCaseAnswerList);
                 }
+
+                String rdbTblNms = String.join(",", investigationCaseAnswerList.stream()
+                                .map(InvestigationCaseAnswer::getRdbTableNm).collect(Collectors.toSet()));
+                investigationTransformed.setRdbTableNameList(rdbTblNms);
             }
             else {
                 logger.info("InvestigationCaseAnswerJsonArray array is null.");

--- a/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/InvestigationDataProcessingTests.java
+++ b/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/InvestigationDataProcessingTests.java
@@ -190,7 +190,8 @@ public class InvestigationDataProcessingTests {
         investigationCaseAnswerDataIfPresent.add(new InvestigationCaseAnswer());
         when(investigationCaseAnswerRepository.findByActUid(investigationUid)).thenReturn(investigationCaseAnswerDataIfPresent);
 
-        transformer.transformInvestigationData(investigation);
+        InvestigationTransformed investigationTransformed = transformer.transformInvestigationData(investigation);
+        assertEquals("D_INV_CLINICAL,D_INV_ADMINISTRATIVE", investigationTransformed.getRdbTableNameList());
 
         List<InvestigationCaseAnswer> caseAnswers = new ArrayList<>();
         caseAnswers.add(caseAnswer);

--- a/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/service/InvestigationServiceTest.java
+++ b/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/service/InvestigationServiceTest.java
@@ -115,6 +115,7 @@ class InvestigationServiceTest {
         investigation.setObservationNotificationIds(readFileData(filePathPrefix + "ObservationNotificationIds.json"));
         investigation.setOrganizationParticipations(readFileData(filePathPrefix + "OrganizationParticipations.json"));
         investigation.setPersonParticipations(readFileData(filePathPrefix + "PersonParticipations.json"));
+        investigation.setInvestigationCaseAnswer(readFileData(filePathPrefix + "InvestigationCaseAnswer.json"));
         return investigation;
     }
 
@@ -127,6 +128,7 @@ class InvestigationServiceTest {
         reporting.setOrganizationId(34865315L);    // OrganizationParticipations.json, entity_id for type_cd=OrgAsReporterOfPHC
         reporting.setInvStateCaseId("12-345-678"); // ActIds.json, root_extension_txt for type_cd=STATE
         reporting.setPhcInvFormId(263748598L);     // ObservationNotificationIds.json, source_act_uid for act_type_cd=PHCInvForm
+        reporting.setRdbTableNameList("D_INV_CLINICAL,D_INV_ADMINISTRATIVE"); // InvestigationCaseAnswer.json, rdb_table_nm
         return reporting;
     }
 }

--- a/data-reporting-service/investigation-service/src/test/resources/rawDataFiles/InvestigationCaseAnswer.json
+++ b/data-reporting-service/investigation-service/src/test/resources/rawDataFiles/InvestigationCaseAnswer.json
@@ -19,6 +19,7 @@
     "other_value_ind_cd": "F",
     "unit_type_cd": null,
     "mask": null,
+    "block_nm": null,
     "question_group_seq_nbr": null,
     "data_type": "CODED",
     "last_chg_time": "2024-05-29T16:05:44.537"
@@ -43,6 +44,7 @@
     "other_value_ind_cd": null,
     "unit_type_cd": null,
     "mask": "TXT",
+    "block_nm": "BLOCK_8",
     "question_group_seq_nbr": null,
     "data_type": "TEXT",
     "last_chg_time": "2024-05-29T16:05:44.537"
@@ -51,8 +53,8 @@
     "nbs_case_answer_uid": 1236,
     "nbs_ui_metadata_uid": 65497312,
     "nbs_rdb_metadata_uid": 41201012,
-    "rdb_table_nm": "D_INV_ADMINISTRATIVE",
-    "rdb_column_nm": "ADM_INNC_NOTIFICATION_DT",
+    "rdb_table_nm": "D_INV_CLINICAL",
+    "rdb_column_nm": "CLN_FDD_Q_160",
     "code_set_group_id": null,
     "answer_txt": "05\/15\/2024",
     "act_uid": 234567890,
@@ -67,6 +69,7 @@
     "other_value_ind_cd": null,
     "unit_type_cd": null,
     "mask": "DATE",
+    "block_nm": null,
     "question_group_seq_nbr": null,
     "data_type": "DATE",
     "last_chg_time": "2024-05-29T16:05:44.537"

--- a/data-reporting-service/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/controller/LdfDataController.java
+++ b/data-reporting-service/ldfdata-service/src/main/java/gov/cdc/etldatapipeline/ldfdata/controller/LdfDataController.java
@@ -24,7 +24,7 @@ public class LdfDataController {
         return ResponseEntity.status(HttpStatus.OK).body("LdfData Preprocessing Service Status OK");
     }
 
-    @PostMapping("/publish")
+    @PostMapping("/reporting/ldfdata-svc/publish")
     public void publishMessageToKafka(@RequestBody String jsonData) {
         producerService.sendMessage(topicName, jsonData);
     }

--- a/data-reporting-service/ldfdata-service/src/test/java/gov/cdc/etldatapipeline/ldfdata/controller/LdfDataControllerTest.java
+++ b/data-reporting-service/ldfdata-service/src/test/java/gov/cdc/etldatapipeline/ldfdata/controller/LdfDataControllerTest.java
@@ -38,7 +38,7 @@ class LdfDataControllerTest {
     void publishMessageToKafkaTest() throws Exception  {
         String jsonData = "{\"key\":\"value\"}";
 
-        mockMvc.perform(post("/publish")
+        mockMvc.perform(post("/reporting/ldfdata-svc/publish")
                         .contentType("application/json")
                         .content(jsonData))
                 .andExpect(status().isOk());

--- a/data-reporting-service/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/PageBuilderRepository.java
+++ b/data-reporting-service/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/PageBuilderRepository.java
@@ -1,0 +1,11 @@
+package gov.cdc.etldatapipeline.postprocessingservice.repository;
+
+import gov.cdc.etldatapipeline.postprocessingservice.repository.model.PageBuilderStoredProc;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.query.Procedure;
+import org.springframework.data.repository.query.Param;
+
+public interface PageBuilderRepository extends JpaRepository<PageBuilderStoredProc, Long> {
+    @Procedure("sp_page_builder_postprocessing")
+    void executeStoredProcForPageBuilder(@Param("phcUid") Long phcUid, @Param("rdbTableNmLst") String rdbTableNmLst);
+}

--- a/data-reporting-service/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/model/PageBuilderStoredProc.java
+++ b/data-reporting-service/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/repository/model/PageBuilderStoredProc.java
@@ -1,0 +1,12 @@
+package gov.cdc.etldatapipeline.postprocessingservice.repository.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Data;
+
+@Data
+@Entity
+public class PageBuilderStoredProc {
+    @Id
+    private Long id;
+}

--- a/data-reporting-service/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
+++ b/data-reporting-service/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
@@ -14,11 +14,10 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -28,12 +27,16 @@ import java.util.stream.Collectors;
 public class PostProcessingService {
     private static final Logger logger = LoggerFactory.getLogger(PostProcessingService.class);
     final Map<String, List<Long>> idCache = new ConcurrentHashMap<>();
+    final Map<Long, String> idVals = new ConcurrentHashMap<>();
 
     private final PatientRepository patientRepository;
     private final ProviderRepository providerRepository;
     private final OrganizationRepository organizationRepository;
     private final InvestigationRepository investigationRepository;
     private final NotificationRepository notificationRepository;
+    private final PageBuilderRepository pageBuilderRepository;
+
+    static final String SP_EXECUTION_COMPLETED = "Stored proc execution completed.";
 
     @KafkaListener(topics = {
             "${spring.kafka.topic.investigation}",
@@ -57,17 +60,22 @@ public class PostProcessingService {
                 String keyTopic = entry.getKey();
                 List<Long> ids = entry.getValue();
                 idCache.put(keyTopic, new ArrayList<>());
-                if(keyTopic.contains("investigation")) {
-                    processTopic(keyTopic, ids, investigationRepository::executeStoredProcForPublicHealthCaseIds, "investigation");
-                }
                 if(keyTopic.contains("organization")) {
                     processTopic(keyTopic, ids, organizationRepository::executeStoredProcForOrganizationIds, "organization");
+                }
+                if(keyTopic.contains("provider")) {
+                    processTopic(keyTopic, ids, providerRepository::executeStoredProcForProviderIds, "provider");
                 }
                 if(keyTopic.contains("patient")) {
                     processTopic(keyTopic, ids, patientRepository::executeStoredProcForPatientIds, "patient");
                 }
-                if(keyTopic.contains("provider")) {
-                    processTopic(keyTopic, ids, providerRepository::executeStoredProcForProviderIds, "provider");
+                if(keyTopic.contains("investigation")) {
+                    processTopic(keyTopic, ids, investigationRepository::executeStoredProcForPublicHealthCaseIds, "investigation");
+                    ids.forEach(id -> {
+                        if (idVals.containsKey(id)) {
+                            processId(id, idVals.get(id), pageBuilderRepository::executeStoredProcForPageBuilder, "case answers");
+                        }
+                    });
                 }
                 if(keyTopic.contains("notifications")) {
                     processTopic(keyTopic, ids, notificationRepository::executeStoredProcForNotificationIds, "notifications");
@@ -95,7 +103,9 @@ public class PostProcessingService {
                 id = jsonNode.get("payload").get("organization_uid").asLong();
             }
             if(topic.contains("investigation")) {
-                id = jsonNode.get("payload").get("public_health_case_uid").asLong();
+                final Long phcUid = id = jsonNode.get("payload").get("public_health_case_uid").asLong();
+                Optional.ofNullable(jsonNode.get("payload").get("rdb_table_name_list"))
+                        .ifPresent(node -> idVals.put(phcUid, node.asText()));
             }
             if(topic.contains("notifications")) {
                 id = jsonNode.get("payload").get("notification_uid").asLong();
@@ -109,9 +119,15 @@ public class PostProcessingService {
     private void processTopic(String keyTopic, List<Long> ids, Consumer<String> repositoryMethod, String entity) {
         if(keyTopic.contains(entity)) {
             String idsString = ids.stream().map(String::valueOf).collect(Collectors.joining(","));
-            logger.info("Processing the ids from the topic {} and calling the stored proc for {}: {}", keyTopic, entity, idsString);
+            logger.info("Processing the ids from the topic '{}' and calling the stored proc for {}: {}", keyTopic, entity, idsString);
             repositoryMethod.accept(idsString);
-            logger.info("Stored proc execution completed.");
+            logger.info(SP_EXECUTION_COMPLETED);
         }
+    }
+
+    private void processId(Long id, String vals,BiConsumer<Long, String> repositoryMethod, String entity) {
+            logger.info("Processing id and calling the stored proc for {}: {}, '{}'", entity, id, vals);
+            repositoryMethod.accept(id, vals);
+            logger.info(SP_EXECUTION_COMPLETED);
     }
 }

--- a/data-reporting-service/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
+++ b/data-reporting-service/post-processing-service/src/main/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingService.java
@@ -61,24 +61,24 @@ public class PostProcessingService {
                 List<Long> ids = entry.getValue();
                 idCache.put(keyTopic, new ArrayList<>());
                 if(keyTopic.contains("organization")) {
-                    processTopic(keyTopic, ids, organizationRepository::executeStoredProcForOrganizationIds, "organization");
+                    processTopic(keyTopic, ids, organizationRepository::executeStoredProcForOrganizationIds, "organization", "sp_nrt_organization_postprocessing");
                 }
                 if(keyTopic.contains("provider")) {
-                    processTopic(keyTopic, ids, providerRepository::executeStoredProcForProviderIds, "provider");
+                    processTopic(keyTopic, ids, providerRepository::executeStoredProcForProviderIds, "provider", "sp_nrt_provider_postprocessing");
                 }
                 if(keyTopic.contains("patient")) {
-                    processTopic(keyTopic, ids, patientRepository::executeStoredProcForPatientIds, "patient");
+                    processTopic(keyTopic, ids, patientRepository::executeStoredProcForPatientIds, "patient", "sp_nrt_patient_postprocessing");
                 }
                 if(keyTopic.contains("investigation")) {
-                    processTopic(keyTopic, ids, investigationRepository::executeStoredProcForPublicHealthCaseIds, "investigation");
+                    processTopic(keyTopic, ids, investigationRepository::executeStoredProcForPublicHealthCaseIds, "investigation","sp_nrt_investigation_postprocessing");
                     ids.forEach(id -> {
                         if (idVals.containsKey(id)) {
-                            processId(id, idVals.get(id), pageBuilderRepository::executeStoredProcForPageBuilder, "case answers");
+                            processId(id, idVals.get(id), pageBuilderRepository::executeStoredProcForPageBuilder, "case answers","sp_page_builder_postprocessing");
                         }
                     });
                 }
                 if(keyTopic.contains("notifications")) {
-                    processTopic(keyTopic, ids, notificationRepository::executeStoredProcForNotificationIds, "notifications");
+                    processTopic(keyTopic, ids, notificationRepository::executeStoredProcForNotificationIds, "notifications", "sp_nrt_notification_postprocessing");
                 }
             }
             else {
@@ -116,17 +116,17 @@ public class PostProcessingService {
         return id;
     }
 
-    private void processTopic(String keyTopic, List<Long> ids, Consumer<String> repositoryMethod, String entity) {
+    private void processTopic(String keyTopic, List<Long> ids, Consumer<String> repositoryMethod, String entity, String proc) {
         if(keyTopic.contains(entity)) {
             String idsString = ids.stream().map(String::valueOf).collect(Collectors.joining(","));
-            logger.info("Processing the ids from the topic '{}' and calling the stored proc for {}: {}", keyTopic, entity, idsString);
+            logger.info("Processing the {} message topic: {}. Calling stored proc: {}('{}')", entity, keyTopic, proc, idsString);
             repositoryMethod.accept(idsString);
             logger.info(SP_EXECUTION_COMPLETED);
         }
     }
 
-    private void processId(Long id, String vals,BiConsumer<Long, String> repositoryMethod, String entity) {
-            logger.info("Processing id and calling the stored proc for {}: {}, '{}'", entity, id, vals);
+    private void processId(Long id, String vals,BiConsumer<Long, String> repositoryMethod, String entity, String proc) {
+            logger.info("Processing PHC ID for {}. Calling stored proc: {}({}, '{}')", entity, proc, id, vals);
             repositoryMethod.accept(id, vals);
             logger.info(SP_EXECUTION_COMPLETED);
     }


### PR DESCRIPTION
## Description

Modifying pre- and post-processing Java services to call Page Builder wrapper `sp_page_builder_postprocessing`

Investigation-service:
- **InvestigationReporting** and InvestigationTransformed: add `rdbTableNameList` field to use in post-processing
- **ProcessInvestigationDataUtil**: update `processInvestigationPageCaseAnswer` to pass `rdbTableNameList` to transformed DTO
- **InvestigationService**: update `buildReportingModelForTransformedData` to process `rdbTableNameList`

Post-processing service:
- **PageBuilderRepository** for **PageBuilderStoredProc**: implements execution of `sp_page_builder_postprocessing`
- **PostProcessingService**: add extraction and processing of `rdb_table_name_list` from investigation message

## Testing
- Unit tests are corrected in accordance with the changes

## JIRA
[CNDIT-1457](https://cdc-nbs.atlassian.net/browse/CNDIT-1457)