### PR TITLE
CNDIT-1538 Fix PK violation on Kafka sink for topic InvestigationKey

### DIFF
--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationKey.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/repository/model/dto/InvestigationKey.java
@@ -11,7 +11,4 @@ public class InvestigationKey {
     @NonNull
     @JsonProperty("public_health_case_uid")
     private Long publicHealthCaseUid;
-
-    @JsonProperty("rdb_table_name_list")
-    private String rdbTableNameList;
 }

--- a/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
+++ b/data-reporting-service/investigation-service/src/main/java/gov/cdc/etldatapipeline/investigation/service/InvestigationService.java
@@ -97,7 +97,6 @@ public class InvestigationService {
                     InvestigationReporting reportingModel = modelMapper.map(investigationData.get(), InvestigationReporting.class);
                     InvestigationTransformed investigationTransformed = processDataUtil.transformInvestigationData(investigationData.get());
                     buildReportingModelForTransformedData(reportingModel, investigationTransformed);
-                    investigationKey.setRdbTableNameList(investigationTransformed.getRdbTableNameList());
                     pushKeyValuePairToKafka(investigationKey, reportingModel, investigationTopicReporting);
                     return objectMapper.writeValueAsString(investigationData.get());
                 }

--- a/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/service/InvestigationServiceTest.java
+++ b/data-reporting-service/investigation-service/src/test/java/gov/cdc/etldatapipeline/investigation/service/InvestigationServiceTest.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import static gov.cdc.etldatapipeline.commonutil.TestUtils.readFileData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class InvestigationServiceTest {
@@ -53,7 +52,7 @@ class InvestigationServiceTest {
     }
 
     @Test
-    public void testProcessMessage() {
+    void testProcessMessage() {
         String investigationTopic = "Investigation";
         String investigationTopicOutput = "InvestigationOutput";
 
@@ -61,11 +60,11 @@ class InvestigationServiceTest {
         String payload = "{\"payload\": {\"after\": {\"public_health_case_uid\": \"" + investigationUid + "\"}}}";
 
         final Investigation investigation = constructInvestigation(investigationUid);
-        when(investigationRepository.computeInvestigations(eq(String.valueOf(investigationUid)))).thenReturn(Optional.of(investigation));
+        when(investigationRepository.computeInvestigations(String.valueOf(investigationUid))).thenReturn(Optional.of(investigation));
 
         validateData(investigationTopic, investigationTopicOutput, payload, investigation);
 
-        verify(investigationRepository).computeInvestigations(eq(String.valueOf(investigationUid)));
+        verify(investigationRepository).computeInvestigations(String.valueOf(investigationUid));
     }
 
     private void validateData(String inputTopicName, String outputTopicName,
@@ -74,10 +73,9 @@ class InvestigationServiceTest {
         final var investigationService = getInvestigationService(inputTopicName, outputTopicName);
         investigationService.processMessage(payload, inputTopicName);
 
-        final InvestigationReporting reportingModel = constructInvestigationReporting(investigation.getPublicHealthCaseUid());
         InvestigationKey investigationKey = new InvestigationKey();
         investigationKey.setPublicHealthCaseUid(investigation.getPublicHealthCaseUid());
-        investigationKey.setRdbTableNameList(reportingModel.getRdbTableNameList());
+        final InvestigationReporting reportingModel = constructInvestigationReporting(investigation.getPublicHealthCaseUid());
 
         String expectedKey = jsonGenerator.generateStringJson(investigationKey);
         String expectedValue = jsonGenerator.generateStringJson(reportingModel);
@@ -87,7 +85,6 @@ class InvestigationServiceTest {
         assertEquals(expectedKey, keyCaptor.getValue());
         assertEquals(expectedValue, messageCaptor.getValue());
         assertTrue(keyCaptor.getValue().contains(String.valueOf(investigationKey.getPublicHealthCaseUid())));
-        assertTrue(keyCaptor.getValue().contains(String.valueOf(investigationKey.getRdbTableNameList())));
     }
 
     private InvestigationService getInvestigationService(String inputTopicName, String outputTopicName) {

--- a/data-reporting-service/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
+++ b/data-reporting-service/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
@@ -7,6 +7,8 @@ import gov.cdc.etldatapipeline.postprocessingservice.repository.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -54,6 +56,19 @@ class PostProcessingServiceTest {
         logger.detachAppender(listAppender);
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "dummy_patient, '{\"payload\":{\"patient_uid\":123}}', 123",
+            "dummy_provider, '{\"payload\":{\"provider_uid\":123}}', 123",
+            "dummy_organization, '{\"payload\":{\"organization_uid\":123}}', 123",
+            "dummy_investigation, '{\"payload\":{\"public_health_case_uid\":123}}', 123",
+            "dummy_notifications, '{\"payload\":{\"notification_uid\":123}}', 123"
+    })
+    void testExtractIdFromMessage(String topic, String messageKey, Long expectedId) {
+        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
+        assertEquals(expectedId, extractedId);
+    }
+
     @Test
     void testPostProcessPatientMessage() {
         String topic = "dummy_patient";
@@ -69,16 +84,6 @@ class PostProcessingServiceTest {
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(3, logs.size());
         assertTrue(logs.get(2).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
-    }
-
-    @Test
-    void testExtractIdFromPatientMessage() {
-        String topic = "dummy_patient";
-        String messageKey = "{\"payload\":{\"patient_uid\":123}}";
-        Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
-
-        assertEquals(expectedId, extractedId);
     }
 
     @Test
@@ -99,16 +104,6 @@ class PostProcessingServiceTest {
     }
 
     @Test
-    void testExtractIdFromProviderMessage() {
-        String topic = "dummy_provider";
-        String messageKey = "{\"payload\":{\"provider_uid\":123}}";
-        Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
-
-        assertEquals(expectedId, extractedId);
-    }
-
-    @Test
     void testPostProcessOrganizationMessage() {
         String topic = "dummy_organization";
         String key = "{\"payload\":{\"organization_uid\":123}}";
@@ -123,16 +118,6 @@ class PostProcessingServiceTest {
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(3, logs.size());
         assertTrue(logs.get(2).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
-    }
-
-    @Test
-    void testExtractIdFromOrganizationMessage() {
-        String topic = "dummy_organization";
-        String messageKey = "{\"payload\":{\"organization_uid\":123}}";
-        Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
-
-        assertEquals(expectedId, extractedId);
     }
 
     @Test
@@ -154,16 +139,6 @@ class PostProcessingServiceTest {
     }
 
     @Test
-    void testExtractIdFromInvestigationMessage() {
-        String topic = "dummy_investigation";
-        String messageKey = "{\"payload\":{\"public_health_case_uid\":123}}";
-        Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
-
-        assertEquals(expectedId, extractedId);
-    }
-
-    @Test
     void testPostProcessNotificationMessage() {
         String topic = "dummy_notifications";
         String key = "{\"payload\":{\"notification_uid\":123}}";
@@ -178,16 +153,6 @@ class PostProcessingServiceTest {
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(3, logs.size());
         assertTrue(logs.get(2).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
-    }
-
-    @Test
-    void testExtractIdFromNotificationMessage() {
-        String topic = "dummy_notifications";
-        String messageKey = "{\"payload\":{\"notification_uid\":123}}";
-        Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
-
-        assertEquals(expectedId, extractedId);
     }
 
     @Test

--- a/data-reporting-service/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
+++ b/data-reporting-service/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class PostProcessingServiceTest {
+class PostProcessingServiceTest {
 
     @InjectMocks
     private PostProcessingService postProcessingServiceMock;
@@ -55,11 +55,11 @@ public class PostProcessingServiceTest {
     }
 
     @Test
-    public void testPostProcessPatientMessage() {
-        String key = "{\"payload\":{\"patient_uid\":123}}";
+    void testPostProcessPatientMessage() {
         String topic = "dummy_patient";
+        String key = "{\"payload\":{\"patient_uid\":123}}";
 
-        postProcessingServiceMock.postProcessMessage(key, topic);
+        postProcessingServiceMock.postProcessMessage(topic, key, key);
         postProcessingServiceMock.processCachedIds();
 
         String expectedPatientIdsString = "123";
@@ -72,21 +72,21 @@ public class PostProcessingServiceTest {
     }
 
     @Test
-    public void testExtractIdFromPatientMessage() {
-        String messageKey = "{\"payload\":{\"patient_uid\":123}}";
+    void testExtractIdFromPatientMessage() {
         String topic = "dummy_patient";
+        String messageKey = "{\"payload\":{\"patient_uid\":123}}";
         Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(messageKey, topic);
+        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
 
         assertEquals(expectedId, extractedId);
     }
 
     @Test
-    public void testPostProcessProviderMessage() {
-        String key = "{\"payload\":{\"provider_uid\":123}}";
+    void testPostProcessProviderMessage() {
         String topic = "dummy_provider";
+        String key = "{\"payload\":{\"provider_uid\":123}}";
 
-        postProcessingServiceMock.postProcessMessage(key, topic);
+        postProcessingServiceMock.postProcessMessage(topic, key, key);
         postProcessingServiceMock.processCachedIds();
 
         String expectedProviderIdsString = "123";
@@ -99,21 +99,21 @@ public class PostProcessingServiceTest {
     }
 
     @Test
-    public void testExtractIdFromProviderMessage() {
-        String messageKey = "{\"payload\":{\"provider_uid\":123}}";
+    void testExtractIdFromProviderMessage() {
         String topic = "dummy_provider";
+        String messageKey = "{\"payload\":{\"provider_uid\":123}}";
         Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(messageKey, topic);
+        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
 
         assertEquals(expectedId, extractedId);
     }
 
     @Test
-    public void testPostProcessOrganizationMessage() {
-        String key = "{\"payload\":{\"organization_uid\":123}}";
+    void testPostProcessOrganizationMessage() {
         String topic = "dummy_organization";
+        String key = "{\"payload\":{\"organization_uid\":123}}";
 
-        postProcessingServiceMock.postProcessMessage(key, topic);
+        postProcessingServiceMock.postProcessMessage(topic, key, key);
         postProcessingServiceMock.processCachedIds();
 
         String expectedOrganizationIdsIdsString = "123";
@@ -126,21 +126,21 @@ public class PostProcessingServiceTest {
     }
 
     @Test
-    public void testExtractIdFromOrganizationMessage() {
-        String messageKey = "{\"payload\":{\"organization_uid\":123}}";
+    void testExtractIdFromOrganizationMessage() {
         String topic = "dummy_organization";
+        String messageKey = "{\"payload\":{\"organization_uid\":123}}";
         Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(messageKey, topic);
+        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
 
         assertEquals(expectedId, extractedId);
     }
 
     @Test
-    public void testPostProcessInvestigationMessage() {
-        String key = "{\"payload\":{\"public_health_case_uid\":123}}";
+    void testPostProcessInvestigationMessage() {
         String topic = "dummy_investigation";
+        String key = "{\"payload\":{\"public_health_case_uid\":123}}";
 
-        postProcessingServiceMock.postProcessMessage(key, topic);
+        postProcessingServiceMock.postProcessMessage(topic, key, key);
         postProcessingServiceMock.processCachedIds();
 
         String expectedPublicHealthCaseIdsString = "123";
@@ -150,25 +150,25 @@ public class PostProcessingServiceTest {
 
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(5, logs.size());
-        assertTrue(logs.get(2).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
+        assertTrue(logs.get(4).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
-    public void testExtractIdFromInvestigationMessage() {
-        String messageKey = "{\"payload\":{\"public_health_case_uid\":123}}";
+    void testExtractIdFromInvestigationMessage() {
         String topic = "dummy_investigation";
+        String messageKey = "{\"payload\":{\"public_health_case_uid\":123}}";
         Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(messageKey, topic);
+        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
 
         assertEquals(expectedId, extractedId);
     }
 
     @Test
-    public void testPostProcessNotificationMessage() {
-        String key = "{\"payload\":{\"notification_uid\":123}}";
+    void testPostProcessNotificationMessage() {
         String topic = "dummy_notifications";
+        String key = "{\"payload\":{\"notification_uid\":123}}";
 
-        postProcessingServiceMock.postProcessMessage(key, topic);
+        postProcessingServiceMock.postProcessMessage(topic, key, key);
         postProcessingServiceMock.processCachedIds();
 
         String expectedNotificationIdsString = "123";
@@ -181,24 +181,25 @@ public class PostProcessingServiceTest {
     }
 
     @Test
-    public void testExtractIdFromNotificationMessage() {
-        String messageKey = "{\"payload\":{\"notification_uid\":123}}";
+    void testExtractIdFromNotificationMessage() {
         String topic = "dummy_notifications";
+        String messageKey = "{\"payload\":{\"notification_uid\":123}}";
         Long expectedId = 123L;
-        Long extractedId = postProcessingServiceMock.extractIdFromMessage(messageKey, topic);
+        Long extractedId = postProcessingServiceMock.extractIdFromMessage(topic, messageKey, messageKey);
 
         assertEquals(expectedId, extractedId);
     }
 
     @Test
-    public void testPostProcessPageBuilder() {
-        String key = "{\"payload\":{\"public_health_case_uid\":123, \"rdb_table_name_list\":\"D_INV_CLINICAL,D_INV_ADMINISTRATIVE\"}}";
+    void testPostProcessPageBuilder() {
         String topic = "dummy_investigation";
+        String key = "{\"payload\":{\"public_health_case_uid\":123}}";
+        String msg = "{\"payload\":{\"public_health_case_uid\":123, \"rdb_table_name_list\":\"D_INV_CLINICAL,D_INV_ADMINISTRATIVE\"}}";
 
         Long expectedPublicHealthCaseId = 123L;
         String expectedRdbTableNames = "D_INV_CLINICAL,D_INV_ADMINISTRATIVE";
 
-        postProcessingServiceMock.postProcessMessage(key, topic);
+        postProcessingServiceMock.postProcessMessage(topic, key, msg);
         assertTrue(postProcessingServiceMock.idVals.containsKey(expectedPublicHealthCaseId));
         assertTrue(postProcessingServiceMock.idVals.containsValue(expectedRdbTableNames));
 
@@ -206,14 +207,13 @@ public class PostProcessingServiceTest {
         assertFalse(postProcessingServiceMock.idVals.containsKey(expectedPublicHealthCaseId));
         verify(pageBuilderRepositoryMock).executeStoredProcForPageBuilder(expectedPublicHealthCaseId, expectedRdbTableNames);
 
-        String expectedMsgInv = "Processing the investigation message topic: " + topic + ". Calling stored proc: sp_nrt_investigation_postprocessing('123')";
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(7, logs.size());
         assertTrue(logs.get(6).getMessage().contains(PostProcessingService.SP_EXECUTION_COMPLETED));
     }
 
     @Test
-    public void testPostProcessMultipleMessages() {
+    void testPostProcessMultipleMessages() {
         String orgKey1 = "{\"payload\":{\"organization_uid\":123}}";
         String orgKey2 = "{\"payload\":{\"organization_uid\":124}}";
         String orgTopic = "dummy_organization";
@@ -222,10 +222,10 @@ public class PostProcessingServiceTest {
         String ntfKey2 = "{\"payload\":{\"notification_uid\":235}}";
         String ntfTopic = "dummy_notifications";
 
-        postProcessingServiceMock.postProcessMessage(orgKey1, orgTopic);
-        postProcessingServiceMock.postProcessMessage(orgKey2, orgTopic);
-        postProcessingServiceMock.postProcessMessage(ntfKey1, ntfTopic);
-        postProcessingServiceMock.postProcessMessage(ntfKey2, ntfTopic);
+        postProcessingServiceMock.postProcessMessage(orgTopic, orgKey1, orgKey1);
+        postProcessingServiceMock.postProcessMessage(orgTopic, orgKey2, orgKey2);
+        postProcessingServiceMock.postProcessMessage(ntfTopic, ntfKey1, ntfKey1);
+        postProcessingServiceMock.postProcessMessage(ntfTopic, ntfKey2, ntfKey2);
 
         postProcessingServiceMock.processCachedIds();
 
@@ -241,7 +241,7 @@ public class PostProcessingServiceTest {
     }
 
     @Test
-    public void testProcessMessageEmptyCache() {
+    void testProcessMessageEmptyCache() {
         String topic = "dummy_patient";
 
         postProcessingServiceMock.idCache.put(topic, new CopyOnWriteArrayList<>());
@@ -253,10 +253,10 @@ public class PostProcessingServiceTest {
     }
 
     @Test
-    public void testExtractIdFromMessageException() {
+    void testExtractIdFromMessageException() {
         String invalidKey = "invalid_key";
         String invalidTopic = "dummy_topic";
 
-        assertThrows(RuntimeException.class, () -> postProcessingServiceMock.extractIdFromMessage(invalidKey, invalidTopic));
+        assertThrows(RuntimeException.class, () -> postProcessingServiceMock.extractIdFromMessage(invalidTopic, invalidKey, invalidKey));
     }
 }


### PR DESCRIPTION
## Description
This PR includes fix the violation of PRIMARY KEY constraint for topic `InvestigationKey` to make it matching the PK in `nrt_investigation` table (`public_health_case_uid`)

Investigation pre-processing:
- **InvestigationKey.java**: remove `rdbTableListNames` field
- **InvestigationService.java**: adjust for `InvestigationKey` changes

Post-processing service:
- **PostProcessingService.java**: 
   add @Payload to KafkaListener method to get access to the entire message payload;
   process payload jsonNode to extract `rdb_table_name_list` value

## JIRA
[CNDIT-1538](https://cdc-nbs.atlassian.net/browse/CNDIT-1538)