### PR TITLE
CNDIT 1519: Kafka sync delay issue

### DIFF
--- a/post-processing-service/src/main/resources/application.yaml
+++ b/post-processing-service/src/main/resources/application.yaml
@@ -25,7 +25,7 @@ spring:
       javax.persistence.query.timeout: -1
 service:
   fixed-delay:
-    cached-ids: ${FIXED_DELAY_ID:5000}
+    cached-ids: ${FIXED_DELAY_ID:20000}
     datamart: ${FIXED_DELAY_DM:60000}
 #logging:
 #  # Only one config can be active at a time

--- a/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
+++ b/post-processing-service/src/test/java/gov/cdc/etldatapipeline/postprocessingservice/service/PostProcessingServiceTest.java
@@ -211,6 +211,39 @@ class PostProcessingServiceTest {
     }
 
     @Test
+    void testPostProcessCacheIdsPriority() {
+        String orgKey = "{\"payload\":{\"organization_uid\":123}}";
+        String providerKey = "{\"payload\":{\"provider_uid\":124}}";
+        String patientKey = "{\"payload\":{\"patient_uid\":125}}";
+        String investigationKey = "{\"payload\":{\"public_health_case_uid\":126}}";
+        String notificationKey = "{\"payload\":{\"notification_uid\":127}}";
+
+        String orgTopic = "dummy_organization";
+        String providerTopic = "dummy_provider";
+        String patientTopic = "dummy_patient";
+        String invTopic = "dummy_investigation";
+        String notfTopic = "dummy_notifications";
+
+        postProcessingServiceMock.postProcessMessage(invTopic, investigationKey, investigationKey);
+        postProcessingServiceMock.postProcessMessage(providerTopic, providerKey, providerKey);
+        postProcessingServiceMock.postProcessMessage(patientTopic, patientKey, patientKey);
+        postProcessingServiceMock.postProcessMessage(notfTopic, notificationKey, notificationKey);
+        postProcessingServiceMock.postProcessMessage(orgTopic, orgKey, orgKey);
+        postProcessingServiceMock.processCachedIds();
+
+        List<ILoggingEvent> logs = listAppender.list;
+        assertEquals(17, logs.size());
+
+        List<String> topicLogList = logs.stream().map(ILoggingEvent::getFormattedMessage).filter(m -> m.contains("message topic")).toList();
+        assertTrue(topicLogList.get(0).contains(orgTopic));
+        assertTrue(topicLogList.get(1).contains(providerTopic));
+        assertTrue(topicLogList.get(2).contains(patientTopic));
+        assertTrue(topicLogList.get(3).contains(invTopic));
+        assertTrue(topicLogList.get(4).contains(invTopic));
+        assertTrue(topicLogList.get(5).contains(notfTopic));
+    }
+
+    @Test
     void testPostProcessDatamart() {
         String topic = "dummy_datamart";
         String msg = "{\"payload\":{\"public_health_case_uid\":123,\"patient_uid\":456," +


### PR DESCRIPTION
## Description
This PR includes fixes for the issue with delayed and asynchronous processing of `nrt_* `topic, which can lead to situation when the expecting patient for Hep Datamart is not yet being processed and stored in the patient dimension table.

- **Application.yaml**: increased default value of configurable fixed delay time for message processor from 5s to 20s
- **PostProcessingService.java**: implemented sorting for topic keys according to their priority, so, e.g. Investigation UIDs (and related messages) will never be processed prior to Patient UIDs.

## JIRA
[CNDIT-1519](https://cdc-nbs.atlassian.net/browse/CNDIT-1519)