### PR TITLE
Cndit 1470: Override the sql server agent status 

### DIFF
--- a/data-reporting-service/src/main/resources/db/changelog/db.odse.changelog-15.1.yaml
+++ b/data-reporting-service/src/main/resources/db/changelog/db.odse.changelog-15.1.yaml
@@ -132,11 +132,3 @@ databaseChangeLog:
         - sqlFile:
             path: src/main/resources/db/odse/018-sp_public_health_case_fact_datamart_event-001.sql
             splitStatements: false
-
-  - changeSet:
-      id: 19
-      author: liquibase
-      changes:
-        - sqlFile:
-            path: src/main/resources/db/odse/019-fn_sql_server_agent_status_override.sql
-            splitStatements: false

--- a/data-reporting-service/src/main/resources/db/changelog/db.odse.changelog-15.1.yaml
+++ b/data-reporting-service/src/main/resources/db/changelog/db.odse.changelog-15.1.yaml
@@ -132,3 +132,11 @@ databaseChangeLog:
         - sqlFile:
             path: src/main/resources/db/odse/018-sp_public_health_case_fact_datamart_event-001.sql
             splitStatements: false
+
+  - changeSet:
+      id: 19
+      author: liquibase
+      changes:
+        - sqlFile:
+            path: src/main/resources/db/odse/019-fn_sql_server_agent_status_override.sql
+            splitStatements: false

--- a/data-reporting-service/src/main/resources/db/master/019-fn_sql_server_agent_status_override.sql
+++ b/data-reporting-service/src/main/resources/db/master/019-fn_sql_server_agent_status_override.sql
@@ -1,5 +1,7 @@
--- This function needs to be created in Azure since the Sql Server agent is not exposed
--- Debezium deployment in Azure AKS need to override this function in the helm chart
+-- This function needs to be created in master since the Sql Server agent is not exposed
+-- We need to override this function in the helm chart distributed properties
+USE MASTER
+
 CREATE OR ALTER FUNCTION dbo.IsSqlAgentRunning() RETURNS BIT AS
 BEGIN
     DECLARE @IsRunning BIT = 0;
@@ -15,3 +17,5 @@ BEGIN
 
     RETURN @IsRunning;
 END;
+
+GRANT VIEW SERVER STATE TO nbs_ods;

--- a/data-reporting-service/src/main/resources/db/odse/019-fn_sql_server_agent_status_override.sql
+++ b/data-reporting-service/src/main/resources/db/odse/019-fn_sql_server_agent_status_override.sql
@@ -1,6 +1,6 @@
 -- This function needs to be created in Azure since the Sql Server agent is not exposed
 -- Debezium deployment in Azure AKS need to override this function in the helm chart
-CREATE FUNCTION dbo.IsSqlAgentRunning() RETURNS BIT AS
+CREATE OR ALTER FUNCTION dbo.IsSqlAgentRunning() RETURNS BIT AS
 BEGIN
     DECLARE @IsRunning BIT = 0;
 

--- a/data-reporting-service/src/main/resources/db/odse/019-fn_sql_server_agent_status_override.sql
+++ b/data-reporting-service/src/main/resources/db/odse/019-fn_sql_server_agent_status_override.sql
@@ -1,0 +1,17 @@
+-- This function needs to be created in Azure since the Sql Server agent is not exposed
+-- Debezium deployment in Azure AKS need to override this function in the helm chart
+CREATE FUNCTION dbo.IsSqlAgentRunning() RETURNS BIT AS
+BEGIN
+    DECLARE @IsRunning BIT = 0;
+
+    IF (EXISTS(SELECT dss.*
+               FROM sys.dm_server_services dss
+               WHERE dss.[servicename] LIKE N'SQL Server Agent (%'
+                 AND dss.[status] = 4 -- Running
+    ))
+        BEGIN
+            SET @IsRunning = 1;
+        END;
+
+    RETURN @IsRunning;
+END;


### PR DESCRIPTION
 This function needs to be created in master since the Sql Server agent is not exposed
We need to override this function in the helm chart distributed properties